### PR TITLE
chore: use node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ yarn install
 # serve with hot reload at localhost:3000
 $ yarn dev
 
-# serve at <YOUR_IP>:3000, to make it accesible for other machines in your network
+# serve at <YOUR_IP>:3000, to make it accessible for other machines in your network
 $ HOST=<YOUR_IP> npm run dev
 
 # build for production and launch server

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "core-js": "^3.37.0",
     "html-webpack-plugin": "5.6",
     "local-pkg": "0.5.0",
-    "node": "14",
+    "node": "16",
     "nuxt": "^2.15.7",
     "nuxt-leaflet": "^0.0.27",
     "push-dir": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7707,10 +7707,10 @@ node-res@^5.0.1:
     on-finished "^2.3.0"
     vary "^1.1.2"
 
-node@14:
-  version "14.21.3"
-  resolved "https://registry.yarnpkg.com/node/-/node-14.21.3.tgz#e6293e9079670bef8f6caf18a515efea1af94609"
-  integrity sha512-58OWd3tZhyABy+OwPGawVKmK5tvlM5Z0TATCSLsiVcIp7NFvMahhzABSkBlnvyiISGcxmainzEAv7L9YJI5EMw==
+node@16:
+  version "16.20.2"
+  resolved "https://registry.yarnpkg.com/node/-/node-16.20.2.tgz#f952a7b055db4e0480606e13fbbfb37d75b3e857"
+  integrity sha512-B4PDiGwFfqDcx7qt1LpDgBfkRAIizDob4dJWAqGC3B1mLV84tHr3nU9MsbeRed7lbcylIb0UBKPVrNZ9PuJRnA==
   dependencies:
     node-bin-setup "^1.0.0"
 


### PR DESCRIPTION
As node 14 is outdated and not available as a precompiled binary for arm64-darwin processors, I need to change it to the next major version (node 16)